### PR TITLE
Change errors to warnings

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -102,6 +102,7 @@ rules:
   no-unused-expressions: 2
   no-useless-call: 2
   no-useless-concat: 2
+  no-useless-escape: 1
   no-void: 2
   no-warning-comments: [ 1, { "terms": [ "todo" ], "location": "anywhere" } ]
   no-with: 2
@@ -152,7 +153,7 @@ rules:
   func-style: 0
   id-length: 0
   id-match: 0
-  indent: [2, tab, {"SwitchCase": 1}]
+  indent: [1, tab, {"SwitchCase": 1}]
   jsx-quotes: 0
   key-spacing: [1, {"beforeColon": false, "afterColon": true}]
   linebreak-style: [2, unix]
@@ -188,7 +189,7 @@ rules:
   one-var: 0
   operator-assignment: 0
   operator-linebreak: 2
-  padded-blocks: [2, "never"]
+  padded-blocks: [1, "never"]
   quote-props: [2, "as-needed", {"keywords": true}]
   quotes: [2, double, avoid-escape]
   require-jsdoc: [2, {"require": {"MethodDefinition": true}}]


### PR DESCRIPTION
Since grunt-eslint to ^20.0.0 (with underlying ESlint 4.0.0), the `indent` and `padded-blocks` rules have become more strict, causing errors to be thrown. There are also errors added for `no-useless-escape`. This PR changes these errors to warnings. Once the existing warnings have been fixed, we can change them back to errors.

## Summary
Change errors to warnings for `indent` and `padded-blocks`. Add warnings for `no-useless-escape`.
