### PR TITLE
Add keyword-spacing rule as warning.

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -156,6 +156,7 @@ rules:
   indent: [1, tab, {"SwitchCase": 1}]
   jsx-quotes: [1, "prefer-double"]
   key-spacing: [1, {"beforeColon": false, "afterColon": true}]
+  keyword-spacing: [1, {"before": true, "after": true}]
   linebreak-style: [2, unix]
   lines-around-comment: 0
   max-depth: 2


### PR DESCRIPTION
Adds the `keyword-spacing` rule, set to throw a warning for now. This rule enforces consistent spacing before and after keywords. Reference: https://eslint.org/docs/rules/keyword-spacing

For example, all the following cases will produce a warning:
```
if(
for(
switch(
return(
```

Fixes #6 