### PR TITLE
Bump the ECMAScript version to 2017

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -3,7 +3,7 @@ extends:
   - "plugin:react/recommended"
 
 parserOptions:
-  ecmaVersion: 6
+  ecmaVersion: 2017
   ecmaFeatures:
     jsx: true
   sourceType: "module"


### PR DESCRIPTION
Bump the ECMAScript version to 2017. Which equals 8.

[See documentation](https://eslint.org/docs/user-guide/configuring#specifying-parser-options)