### PR TITLE
Check for textdomain on translation calls

### DIFF
--- a/default.yml
+++ b/default.yml
@@ -180,7 +180,21 @@ rules:
   no-nested-ternary: 2
   no-new-object: 2
   no-plusplus: 0
-  no-restricted-syntax: 0
+  no-restricted-syntax: [
+    'error',
+    {
+      selector: 'CallExpression[callee.name=/^(__|_x)$/][arguments.length!=2]',
+      message: 'A textdomain needs to be provided for translation calls.',
+    },
+    {
+      selector: 'CallExpression[callee.name=/^(_n)$/][arguments.length!=4]',
+      message: 'A textdomain needs to be provided for translation calls.',
+    },
+    {
+      selector: 'CallExpression[callee.name=/^(_nx)$/][arguments.length!=5]',
+      message: 'A textdomain needs to be provided for translation calls.',
+    }
+  ]
   no-spaced-func: 1
   no-ternary: 0
   no-trailing-spaces: 2

--- a/default.yml
+++ b/default.yml
@@ -183,7 +183,11 @@ rules:
   no-restricted-syntax: [
     'error',
     {
-      selector: 'CallExpression[callee.name=/^(__|_x)$/][arguments.length!=2]',
+      selector: 'CallExpression[callee.name=/^(__)$/][arguments.length!=2]',
+      message: 'A textdomain needs to be provided for translation calls.',
+    },
+    {
+      selector: 'CallExpression[callee.name=/^(_x)$/][arguments.length!=3]',
       message: 'A textdomain needs to be provided for translation calls.',
     },
     {


### PR DESCRIPTION
A textdomain needs to be specified when using translation calls.

This can be tested on the `yoast-components` repository, using the following command:
`yarn add eslint-plugin-yoast https://github.com/Yoast/eslint.git#check-translation-calls-for-textdomain --dev`

Followed by a `grunt check`

This will result in 4 errors (and a bunch of warnings, as the current version of eslint is `^1.0.0` instead of the `3.1.0` that this is based on via `master`.