### PR TITLE
Simplify JSX a11y rules to use the recommended ones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,27 @@
-/.idea
+node_modules/
+
+############
+## OSes
+############
+
+[Tt]humbs.db
+[Dd]esktop.ini
+*.DS_store
+.DS_store?
+
+############
+## Misc
+############
+
+*.tmp
+*.bak
+*.log
+*.[Cc]ache
+*.cpr
+*.orig
+*.php.in
+.idea/
+temp/
+._*
+.Trashes
+.svn

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 node_modules/
+package-lock.json
 
 ############
 ## OSes

--- a/README.md
+++ b/README.md
@@ -14,6 +14,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+### 5.0 - 2018-09-21
+
+#### Breaking changes
+
+* Use the JSX a11y recommended rules, only exception is `label-has-for`.
+
+#### Changed
+
+* Sets `react/button-has-type` to warning as this rule [is pretty useless in its current state](https://github.com/yannickcr/eslint-plugin-react/issues/1555).
+* Adds an exception for translators comments in `capitalized-comments`.
+
 ### 4.0 - 2018-09-07
 
 #### Breaking changes

--- a/default.yml
+++ b/default.yml
@@ -1,6 +1,7 @@
 extends:
   - "eslint:recommended"
   - "plugin:react/recommended"
+  - "plugin:jsx-a11y/recommended"
 
 parserOptions:
   ecmaVersion: 2017
@@ -226,31 +227,8 @@ rules:
   spaced-comment: [2, "always"]
   wrap-regex: 0
 
-
   # Accessibility rules. https://github.com/evcohen/eslint-plugin-jsx-a11y
-  jsx-a11y/anchor-has-content: 1 # Passes if it's empty but has an aria-label attribute.
-  jsx-a11y/aria-props: 2
-  jsx-a11y/aria-proptypes: 2
-  jsx-a11y/aria-role: 2
-  jsx-a11y/aria-unsupported-elements: 2
-  jsx-a11y/click-events-have-key-events: 2
-  jsx-a11y/heading-has-content: 2
-  jsx-a11y/href-no-hash: 1 # Checks only for `#` and doesn't check other invalid values. Passes if it has a role="button". However, consider to use a real button.
-  jsx-a11y/html-has-lang: 2
-  jsx-a11y/img-has-alt: 2
-  jsx-a11y/img-redundant-alt: 2
-  jsx-a11y/label-has-for: 1 # Checks only for the presence of the for attribute. Doesn't check if the for value is correct. Doesn't check for missing labels. A bit pointless.
-  jsx-a11y/mouse-events-have-key-events: 1 # Should be evaluated on a case by case basis.
-  jsx-a11y/no-access-key: 2
-  jsx-a11y/no-marquee: 2
-  jsx-a11y/no-onchange: 1 # Should be evaluated on a case by case basis. Try to avoid onchange anyways.
-  jsx-a11y/no-static-element-interactions: 1
-  jsx-a11y/onclick-has-focus: 2
-  jsx-a11y/onclick-has-role: 2
-  jsx-a11y/role-has-required-aria-props: 2
-  jsx-a11y/role-supports-aria-props: 2
-  jsx-a11y/scope: 2
-  jsx-a11y/tabindex-no-positive: 2
+  jsx-a11y/label-has-for: [ "error", { required: "id" } ]
 
   # React plugins settings (https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules)
   react/jsx-tag-spacing: [2, {"beforeClosing": "never"}]

--- a/default.yml
+++ b/default.yml
@@ -23,7 +23,7 @@ plugins:
 # http://eslint.org/docs/rules/
 rules:
   # Possible Errors
-  comma-dangle: [2, always-multiline]
+  comma-dangle: [2, "always-multiline"]
   no-cond-assign: 2
   no-console: [ 2, { allow: ["warn", "error", "trace"] } ]
   no-constant-condition: 2
@@ -59,7 +59,7 @@ rules:
   # Best Practices
   accessor-pairs: 2
   block-scoped-var: 0
-  complexity: [2, 6]
+  complexity: [1, 6]
   consistent-return: 0
   curly: 2
   default-case: 0
@@ -123,7 +123,7 @@ rules:
   no-delete-var: 2
   no-label-var: 2
   no-shadow-restricted-names: 2
-  no-shadow: [ 2, { "builtinGlobals": false, "hoist": "all", "allow": [] } ]
+  no-shadow: [ 1, { "builtinGlobals": false, "hoist": "all", "allow": [] } ]
   no-undef-init: 2
   no-undef: 2
   no-undefined: 2
@@ -143,14 +143,14 @@ rules:
   no-sync: 0
 
   # Stylistic Issues
-  array-bracket-spacing: [2, always]
-  block-spacing: [2, always]
+  array-bracket-spacing: [2, "always"]
+  block-spacing: [2, "always"]
   brace-style: [2, 1tbs]
   camelcase: 2
-  capitalized-comments: 2
+  capitalized-comments: [2, "always", { "ignorePattern": "translators" }]
   comma-spacing: 2
   comma-style: 2
-  computed-property-spacing: [2, always]
+  computed-property-spacing: [2, "always"]
   consistent-this: [2, "that"]
   eol-last: 2
   func-names: 0
@@ -215,9 +215,9 @@ rules:
   padded-blocks: [2, "never"]
   quote-props: [2, "as-needed", {"keywords": true}]
   quotes: [2, double, avoid-escape]
-  require-jsdoc: [2, {"require": {"MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true}}]
+  require-jsdoc: 1
   semi-spacing: 2
-  semi: [2, always]
+  semi: [2, "always"]
   sort-vars: 0
   space-before-blocks: 2
   space-before-function-paren: [2, "never"]
@@ -258,5 +258,5 @@ rules:
   react/no-access-state-in-setstate: 2
   react/forbid-foreign-prop-types: 2
   react/default-props-match-prop-types: 2
-  react/button-has-type: 2
+  react/button-has-type: 1 # See https://github.com/yannickcr/eslint-plugin-react/issues/1555
   react/boolean-prop-naming: 2

--- a/default.yml
+++ b/default.yml
@@ -228,6 +228,7 @@ rules:
   wrap-regex: 0
 
   # Accessibility rules. https://github.com/evcohen/eslint-plugin-jsx-a11y
+  # Deprecated in v6.1.0 in favor of label-has-associated-control but we still want to require only for/id and not nesting.
   jsx-a11y/label-has-for: [ "error", { required: "id" } ]
 
   # React plugins settings (https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules)

--- a/default.yml
+++ b/default.yml
@@ -229,7 +229,7 @@ rules:
 
   # Accessibility rules. https://github.com/evcohen/eslint-plugin-jsx-a11y
   # Deprecated in v6.1.0 in favor of label-has-associated-control but we still want to require only for/id and not nesting.
-  jsx-a11y/label-has-for: [ "error", { required: "id" } ]
+  jsx-a11y/label-has-for: [ 2, { "required": "id" } ]
 
   # React plugins settings (https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules)
   react/jsx-tag-spacing: [2, {"beforeClosing": "never"}]

--- a/default.yml
+++ b/default.yml
@@ -258,5 +258,5 @@ rules:
   react/no-access-state-in-setstate: 2
   react/forbid-foreign-prop-types: 2
   react/default-props-match-prop-types: 2
-  react/button-has-type: 1 # See https://github.com/yannickcr/eslint-plugin-react/issues/1555
+  react/button-has-type: 0 # See https://github.com/yannickcr/eslint-plugin-react/issues/1555
   react/boolean-prop-naming: 2

--- a/default.yml
+++ b/default.yml
@@ -59,7 +59,7 @@ rules:
   # Best Practices
   accessor-pairs: 2
   block-scoped-var: 0
-  complexity: [1, 6]
+  complexity: [2, 6]
   consistent-return: 0
   curly: 2
   default-case: 0
@@ -123,7 +123,7 @@ rules:
   no-delete-var: 2
   no-label-var: 2
   no-shadow-restricted-names: 2
-  no-shadow: [ 1, { "builtinGlobals": false, "hoist": "all", "allow": [] } ]
+  no-shadow: [ 2, { "builtinGlobals": false, "hoist": "all", "allow": [] } ]
   no-undef-init: 2
   no-undef: 2
   no-undefined: 2
@@ -143,14 +143,14 @@ rules:
   no-sync: 0
 
   # Stylistic Issues
-  array-bracket-spacing: [2, "always"]
-  block-spacing: [2, "always"]
+  array-bracket-spacing: [2, always]
+  block-spacing: [2, always]
   brace-style: [2, 1tbs]
   camelcase: 2
-  capitalized-comments: [2, "always", { "ignorePattern": "translators" }]
+  capitalized-comments: [2, always, { "ignorePattern": "translators" }]
   comma-spacing: 2
   comma-style: 2
-  computed-property-spacing: [2, "always"]
+  computed-property-spacing: [2, always]
   consistent-this: [2, "that"]
   eol-last: 2
   func-names: 0
@@ -215,9 +215,9 @@ rules:
   padded-blocks: [2, "never"]
   quote-props: [2, "as-needed", {"keywords": true}]
   quotes: [2, double, avoid-escape]
-  require-jsdoc: 1
+  require-jsdoc: [2, {"require": {"MethodDefinition": true, "ClassDeclaration": true, "ArrowFunctionExpression": true, "FunctionExpression": true}}]
   semi-spacing: 2
-  semi: [2, "always"]
+  semi: [2, always]
   sort-vars: 0
   space-before-blocks: 2
   space-before-function-paren: [2, "never"]
@@ -229,7 +229,7 @@ rules:
 
   # Accessibility rules. https://github.com/evcohen/eslint-plugin-jsx-a11y
   # Deprecated in v6.1.0 in favor of label-has-associated-control but we still want to require only for/id and not nesting.
-  jsx-a11y/label-has-for: [ 2, { "required": "id" } ]
+  jsx-a11y/label-has-for: [2, { "required": "id" } ]
 
   # React plugins settings (https://github.com/yannickcr/eslint-plugin-react/tree/master/docs/rules)
   react/jsx-tag-spacing: [2, {"beforeClosing": "never"}]

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-yoast",
-  "version": "4.0.1",
+  "version": "5.0.0",
   "description": "ESLint configuration for Yoast projects",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-yoast",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "ESLint configuration for Yoast projects",
   "keywords": [
     "eslint",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "js-yaml": "^3.6.0"
   },
   "peerDependencies": {
-    "eslint-plugin-react": ">=6.0.0",
+    "eslint-plugin-react": ">=7.11.1",
     "eslint-plugin-jsx-a11y": ">=6.1.1"
   }
 }


### PR DESCRIPTION
- uses the jsx-a11y/recommended rules
- with one exception for `label-has-for`, which is deprecated in v6.1.0 in favor of `label-has-associated-control` but we still want to require only for/id and not nesting
- sets `react/button-has-type` to warning as this rule [is pretty useless in its current state](https://github.com/yannickcr/eslint-plugin-react/issues/1555)
- adds an exception for translators comments in `capitalized-comments`

Fixes #12 